### PR TITLE
Add a redirect for new Usernames to UUIDs endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 
 # Composer
 /vendor
-composer.phar
 
 # Mac DS_Store Files
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Composer
 /vendor
+composer.phar
 
 # Mac DS_Store Files
 .DS_Store

--- a/api/config/routes.php
+++ b/api/config/routes.php
@@ -41,6 +41,7 @@ return [
     '/minecraft/session/hasJoined' => 'session/session/has-joined',
     '/minecraft/session/legacy/hasJoined' => 'session/session/has-joined-legacy',
     '/minecraft/session/profile/<uuid>' => 'session/session/profile',
+    'POST /minecraft/session/profile/lookup/bulk/byname' => 'mojang/api/uuids-by-usernames',
 
     // Mojang API module routes
     '/mojang/profiles/<username>' => 'mojang/api/uuid-by-username',

--- a/api/config/routes.php
+++ b/api/config/routes.php
@@ -55,4 +55,5 @@ return [
     '/authlib-injector/sessionserver/session/minecraft/hasJoined' => 'session/session/has-joined',
     '/authlib-injector/sessionserver/session/minecraft/profile/<uuid>' => 'session/session/profile',
     '/authlib-injector/api/profiles/minecraft' => 'mojang/api/uuids-by-usernames',
+    '/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname' => 'mojang/api/uuids-by-usernames',
 ];

--- a/api/tests/_pages/MojangApiRoute.php
+++ b/api/tests/_pages/MojangApiRoute.php
@@ -12,8 +12,8 @@ class MojangApiRoute extends BasePage {
         $this->getActor()->sendGET("/api/mojang/profiles/{$uuid}/names");
     }
 
-    public function uuidsByUsernames($uuids) {
-        $this->getActor()->sendPOST('/api/mojang/profiles', $uuids);
+    public function uuidsByUsernames($url, $uuids) {
+        $this->getActor()->sendPOST($url, $uuids);
     }
 
 }

--- a/api/tests/_pages/MojangApiRoute.php
+++ b/api/tests/_pages/MojangApiRoute.php
@@ -11,9 +11,4 @@ class MojangApiRoute extends BasePage {
     public function usernamesByUuid($uuid) {
         $this->getActor()->sendGET("/api/mojang/profiles/{$uuid}/names");
     }
-
-    public function uuidsByUsernames($url, $uuids) {
-        $this->getActor()->sendPOST($url, $uuids);
-    }
-
 }

--- a/api/tests/functional/authlibInjector/MinecraftProfilesCest.php
+++ b/api/tests/functional/authlibInjector/MinecraftProfilesCest.php
@@ -9,8 +9,7 @@ use Codeception\Example;
 final class MinecraftProfilesCest {
 
     /**
-     * @example ["/api/authlib-injector/api/profiles/minecraft"]
-     * @example ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
+     * @dataProvider bulkProfilesEndpoints
      */
     public function getUuidByOneUsername(FunctionalTester $I, Example $url) {
         $I->sendPOST($url[0], ['Admin']);
@@ -24,8 +23,7 @@ final class MinecraftProfilesCest {
     }
 
     /**
-     * @example ["/api/authlib-injector/api/profiles/minecraft"]
-     * @example ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
+     * @dataProvider bulkProfilesEndpoints
      */
     public function getUuidsByUsernames(FunctionalTester $I, Example $url) {
         $I->sendPOST($url[0], ['Admin', 'AccWithOldPassword', 'Notch']);
@@ -34,8 +32,7 @@ final class MinecraftProfilesCest {
 
 
     /**
-     * @example ["/api/authlib-injector/api/profiles/minecraft"]
-     * @example ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
+     * @dataProvider bulkProfilesEndpoints
      */
     public function getUuidsByUsernamesWithPostString(FunctionalTester $I, Example $url) {
         $I->sendPOST(
@@ -47,8 +44,7 @@ final class MinecraftProfilesCest {
 
 
     /**
-     * @example ["/api/authlib-injector/api/profiles/minecraft"]
-     * @example ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
+     * @dataProvider bulkProfilesEndpoints
      */
     public function getUuidsByPartialNonexistentUsernames(FunctionalTester $I, Example $url) {
         $I->sendPOST($url[0], ['Admin', 'DeletedAccount', 'not-exists-user']);
@@ -65,8 +61,7 @@ final class MinecraftProfilesCest {
 
 
     /**
-     * @example ["/api/authlib-injector/api/profiles/minecraft"]
-     * @example ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
+     * @dataProvider bulkProfilesEndpoints
      */
     public function passAllNonexistentUsernames(FunctionalTester $I, Example $url) {
         $I->sendPOST($url[0], ['not-exists-1', 'not-exists-2']);
@@ -77,8 +72,7 @@ final class MinecraftProfilesCest {
 
 
     /**
-     * @example ["/api/authlib-injector/api/profiles/minecraft"]
-     * @example ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
+     * @dataProvider bulkProfilesEndpoints
      */
     public function passTooManyUsernames(FunctionalTester $I, Example $url) {
         $usernames = [];
@@ -96,8 +90,7 @@ final class MinecraftProfilesCest {
 
 
     /**
-     * @example ["/api/authlib-injector/api/profiles/minecraft"]
-     * @example ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
+     * @dataProvider bulkProfilesEndpoints
      */
     public function passEmptyUsername(FunctionalTester $I, Example $url) {
         $I->sendPOST($url[0], ['Admin', '']);
@@ -110,8 +103,7 @@ final class MinecraftProfilesCest {
 
 
     /**
-     * @example ["/api/authlib-injector/api/profiles/minecraft"]
-     * @example ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
+     * @dataProvider bulkProfilesEndpoints
      */
     public function passEmptyField(FunctionalTester $I, Example $url) {
         $I->sendPOST($url[0], []);
@@ -139,6 +131,13 @@ final class MinecraftProfilesCest {
                 'name' => 'Notch',
             ],
         ]);
+    }
+
+    private function bulkProfilesEndpoints() : array {
+        return [
+            ["/api/authlib-injector/api/profiles/minecraft"],
+            ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
+        ];
     }
 
 }

--- a/api/tests/functional/authlibInjector/MinecraftProfilesCest.php
+++ b/api/tests/functional/authlibInjector/MinecraftProfilesCest.php
@@ -4,11 +4,16 @@ declare(strict_types=1);
 namespace api\tests\functional\authlibInjector;
 
 use api\tests\FunctionalTester;
+use Codeception\Example;
 
 final class MinecraftProfilesCest {
 
-    public function geUuidByOneUsername(FunctionalTester $I) {
-        $I->sendPOST('/api/authlib-injector/api/profiles/minecraft', ['Admin']);
+    /**
+     * @example ["/api/authlib-injector/api/profiles/minecraft"]
+     * @example ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
+     */
+    public function getUuidByOneUsername(FunctionalTester $I, Example $url) {
+        $I->sendPOST($url[0], ['Admin']);
         $I->canSeeResponseCodeIs(200);
         $I->canSeeResponseContainsJson([
             [
@@ -18,21 +23,35 @@ final class MinecraftProfilesCest {
         ]);
     }
 
-    public function getUuidsByUsernames(FunctionalTester $I) {
-        $I->sendPOST('/api/authlib-injector/api/profiles/minecraft', ['Admin', 'AccWithOldPassword', 'Notch']);
+    /**
+     * @example ["/api/authlib-injector/api/profiles/minecraft"]
+     * @example ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
+     */
+    public function getUuidsByUsernames(FunctionalTester $I, Example $url) {
+        $I->sendPOST($url[0], ['Admin', 'AccWithOldPassword', 'Notch']);
         $this->validateFewValidUsernames($I);
     }
 
-    public function getUuidsByUsernamesWithPostString(FunctionalTester $I) {
+
+    /**
+     * @example ["/api/authlib-injector/api/profiles/minecraft"]
+     * @example ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
+     */
+    public function getUuidsByUsernamesWithPostString(FunctionalTester $I, Example $url) {
         $I->sendPOST(
-            '/api/authlib-injector/api/profiles/minecraft',
+            $url[0],
             json_encode(['Admin', 'AccWithOldPassword', 'Notch']),
         );
         $this->validateFewValidUsernames($I);
     }
 
-    public function getUuidsByPartialNonexistentUsernames(FunctionalTester $I) {
-        $I->sendPOST('/api/authlib-injector/api/profiles/minecraft', ['Admin', 'DeletedAccount', 'not-exists-user']);
+
+    /**
+     * @example ["/api/authlib-injector/api/profiles/minecraft"]
+     * @example ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
+     */
+    public function getUuidsByPartialNonexistentUsernames(FunctionalTester $I, Example $url) {
+        $I->sendPOST($url[0], ['Admin', 'DeletedAccount', 'not-exists-user']);
         $I->canSeeResponseCodeIs(200);
         $I->canSeeResponseContainsJson([
             [
@@ -44,20 +63,30 @@ final class MinecraftProfilesCest {
         $I->cantSeeResponseJsonMatchesJsonPath('$.[?(@.name="not-exists-user")]');
     }
 
-    public function passAllNonexistentUsernames(FunctionalTester $I) {
-        $I->sendPOST('/api/authlib-injector/api/profiles/minecraft', ['not-exists-1', 'not-exists-2']);
+
+    /**
+     * @example ["/api/authlib-injector/api/profiles/minecraft"]
+     * @example ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
+     */
+    public function passAllNonexistentUsernames(FunctionalTester $I, Example $url) {
+        $I->sendPOST($url[0], ['not-exists-1', 'not-exists-2']);
         $I->canSeeResponseCodeIs(200);
         $I->canSeeResponseIsJson();
         $I->canSeeResponseEquals('[]');
     }
 
-    public function passTooManyUsernames(FunctionalTester $I) {
+
+    /**
+     * @example ["/api/authlib-injector/api/profiles/minecraft"]
+     * @example ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
+     */
+    public function passTooManyUsernames(FunctionalTester $I, Example $url) {
         $usernames = [];
         for ($i = 0; $i < 150; $i++) {
             $usernames[] = random_bytes(10);
         }
 
-        $I->sendPOST('/api/authlib-injector/api/profiles/minecraft', $usernames);
+        $I->sendPOST($url[0], $usernames);
         $I->canSeeResponseCodeIs(400);
         $I->canSeeResponseContainsJson([
             'error' => 'IllegalArgumentException',
@@ -65,8 +94,13 @@ final class MinecraftProfilesCest {
         ]);
     }
 
-    public function passEmptyUsername(FunctionalTester $I) {
-        $I->sendPOST('/api/authlib-injector/api/profiles/minecraft', ['Admin', '']);
+
+    /**
+     * @example ["/api/authlib-injector/api/profiles/minecraft"]
+     * @example ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
+     */
+    public function passEmptyUsername(FunctionalTester $I, Example $url) {
+        $I->sendPOST($url[0], ['Admin', '']);
         $I->canSeeResponseCodeIs(400);
         $I->canSeeResponseContainsJson([
             'error' => 'IllegalArgumentException',
@@ -74,8 +108,13 @@ final class MinecraftProfilesCest {
         ]);
     }
 
-    public function passEmptyField(FunctionalTester $I) {
-        $I->sendPOST('/api/authlib-injector/api/profiles/minecraft', []);
+
+    /**
+     * @example ["/api/authlib-injector/api/profiles/minecraft"]
+     * @example ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
+     */
+    public function passEmptyField(FunctionalTester $I, Example $url) {
+        $I->sendPOST($url[0], []);
         $I->canSeeResponseCodeIs(400);
         $I->canSeeResponseContainsJson([
             'error' => 'IllegalArgumentException',

--- a/api/tests/functional/authlibInjector/MinecraftProfilesCest.php
+++ b/api/tests/functional/authlibInjector/MinecraftProfilesCest.php
@@ -11,7 +11,7 @@ final class MinecraftProfilesCest {
     /**
      * @dataProvider bulkProfilesEndpoints
      */
-    public function getUuidByOneUsername(FunctionalTester $I, Example $url) {
+    public function getUuidByOneUsername(FunctionalTester $I, Example $url) : void {
         $I->sendPOST($url[0], ['Admin']);
         $I->canSeeResponseCodeIs(200);
         $I->canSeeResponseContainsJson([
@@ -25,7 +25,7 @@ final class MinecraftProfilesCest {
     /**
      * @dataProvider bulkProfilesEndpoints
      */
-    public function getUuidsByUsernames(FunctionalTester $I, Example $url) {
+    public function getUuidsByUsernames(FunctionalTester $I, Example $url) : void {
         $I->sendPOST($url[0], ['Admin', 'AccWithOldPassword', 'Notch']);
         $this->validateFewValidUsernames($I);
     }
@@ -34,7 +34,7 @@ final class MinecraftProfilesCest {
     /**
      * @dataProvider bulkProfilesEndpoints
      */
-    public function getUuidsByUsernamesWithPostString(FunctionalTester $I, Example $url) {
+    public function getUuidsByUsernamesWithPostString(FunctionalTester $I, Example $url) : void {
         $I->sendPOST(
             $url[0],
             json_encode(['Admin', 'AccWithOldPassword', 'Notch']),
@@ -46,7 +46,7 @@ final class MinecraftProfilesCest {
     /**
      * @dataProvider bulkProfilesEndpoints
      */
-    public function getUuidsByPartialNonexistentUsernames(FunctionalTester $I, Example $url) {
+    public function getUuidsByPartialNonexistentUsernames(FunctionalTester $I, Example $url) : void {
         $I->sendPOST($url[0], ['Admin', 'DeletedAccount', 'not-exists-user']);
         $I->canSeeResponseCodeIs(200);
         $I->canSeeResponseContainsJson([
@@ -63,7 +63,7 @@ final class MinecraftProfilesCest {
     /**
      * @dataProvider bulkProfilesEndpoints
      */
-    public function passAllNonexistentUsernames(FunctionalTester $I, Example $url) {
+    public function passAllNonexistentUsernames(FunctionalTester $I, Example $url) : void {
         $I->sendPOST($url[0], ['not-exists-1', 'not-exists-2']);
         $I->canSeeResponseCodeIs(200);
         $I->canSeeResponseIsJson();
@@ -74,7 +74,7 @@ final class MinecraftProfilesCest {
     /**
      * @dataProvider bulkProfilesEndpoints
      */
-    public function passTooManyUsernames(FunctionalTester $I, Example $url) {
+    public function passTooManyUsernames(FunctionalTester $I, Example $url) : void {
         $usernames = [];
         for ($i = 0; $i < 150; $i++) {
             $usernames[] = random_bytes(10);
@@ -92,7 +92,7 @@ final class MinecraftProfilesCest {
     /**
      * @dataProvider bulkProfilesEndpoints
      */
-    public function passEmptyUsername(FunctionalTester $I, Example $url) {
+    public function passEmptyUsername(FunctionalTester $I, Example $url) : void {
         $I->sendPOST($url[0], ['Admin', '']);
         $I->canSeeResponseCodeIs(400);
         $I->canSeeResponseContainsJson([
@@ -105,7 +105,7 @@ final class MinecraftProfilesCest {
     /**
      * @dataProvider bulkProfilesEndpoints
      */
-    public function passEmptyField(FunctionalTester $I, Example $url) {
+    public function passEmptyField(FunctionalTester $I, Example $url) : void {
         $I->sendPOST($url[0], []);
         $I->canSeeResponseCodeIs(400);
         $I->canSeeResponseContainsJson([
@@ -114,7 +114,7 @@ final class MinecraftProfilesCest {
         ]);
     }
 
-    private function validateFewValidUsernames(FunctionalTester $I) {
+    private function validateFewValidUsernames(FunctionalTester $I) : void {
         $I->canSeeResponseCodeIs(200);
         $I->canSeeResponseIsJson();
         $I->canSeeResponseContainsJson([

--- a/api/tests/functional/mojang/UsernamesToUuidsCest.php
+++ b/api/tests/functional/mojang/UsernamesToUuidsCest.php
@@ -3,6 +3,7 @@ namespace api\tests\functional\authserver;
 
 use api\tests\_pages\MojangApiRoute;
 use api\tests\FunctionalTester;
+use Codeception\Example;
 
 class UsernamesToUuidsCest {
 
@@ -15,9 +16,13 @@ class UsernamesToUuidsCest {
         $this->route = new MojangApiRoute($I);
     }
 
-    public function geUuidByOneUsername(FunctionalTester $I) {
+    /**
+     * @example ["/api/authlib-injector/api/profiles/minecraft"]
+     * @example ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
+     */
+    public function getUuidByOneUsername(FunctionalTester $I, Example $url) {
         $I->wantTo('get uuid by one username');
-        $this->route->uuidsByUsernames(['Admin']);
+        $this->route->uuidsByUsernames($url[0], ['Admin']);
         $I->canSeeResponseCodeIs(200);
         $I->canSeeResponseIsJson();
         $I->canSeeResponseContainsJson([
@@ -28,21 +33,33 @@ class UsernamesToUuidsCest {
         ]);
     }
 
-    public function getUuidsByUsernames(FunctionalTester $I) {
+    /**
+     * @example ["/api/authlib-injector/api/profiles/minecraft"]
+     * @example ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
+     */
+    public function getUuidsByUsernames(FunctionalTester $I, Example $url) {
         $I->wantTo('get uuids by few usernames');
-        $this->route->uuidsByUsernames(['Admin', 'AccWithOldPassword', 'Notch']);
+        $this->route->uuidsByUsernames($url[0], ['Admin', 'AccWithOldPassword', 'Notch']);
         $this->validateFewValidUsernames($I);
     }
 
-    public function getUuidsByUsernamesWithPostString(FunctionalTester $I) {
+    /**
+     * @example ["/api/authlib-injector/api/profiles/minecraft"]
+     * @example ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
+     */
+    public function getUuidsByUsernamesWithPostString(FunctionalTester $I, Example $url) {
         $I->wantTo('get uuids by few usernames');
-        $this->route->uuidsByUsernames(json_encode(['Admin', 'AccWithOldPassword', 'Notch']));
+        $this->route->uuidsByUsernames($url[0], json_encode(['Admin', 'AccWithOldPassword', 'Notch']));
         $this->validateFewValidUsernames($I);
     }
 
-    public function getUuidsByPartialNonexistentUsernames(FunctionalTester $I) {
+    /**
+     * @example ["/api/authlib-injector/api/profiles/minecraft"]
+     * @example ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
+     */
+    public function getUuidsByPartialNonexistentUsernames(FunctionalTester $I, Example $url) {
         $I->wantTo('get uuids by few usernames and some nonexistent');
-        $this->route->uuidsByUsernames(['Admin', 'DeletedAccount', 'not-exists-user']);
+        $this->route->uuidsByUsernames($url[0], ['Admin', 'DeletedAccount', 'not-exists-user']);
         $I->canSeeResponseCodeIs(200);
         $I->canSeeResponseIsJson();
         $I->canSeeResponseContainsJson([
@@ -55,22 +72,30 @@ class UsernamesToUuidsCest {
         $I->cantSeeResponseJsonMatchesJsonPath('$.[?(@.name="not-exists-user")]');
     }
 
-    public function passAllNonexistentUsernames(FunctionalTester $I) {
+    /**
+     * @example ["/api/authlib-injector/api/profiles/minecraft"]
+     * @example ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
+     */
+    public function passAllNonexistentUsernames(FunctionalTester $I, Example $url) {
         $I->wantTo('get specific response when pass all nonexistent usernames');
-        $this->route->uuidsByUsernames(['not-exists-1', 'not-exists-2']);
+        $this->route->uuidsByUsernames($url[0], ['not-exists-1', 'not-exists-2']);
         $I->canSeeResponseCodeIs(200);
         $I->canSeeResponseIsJson();
         $I->canSeeResponseContainsJson([]);
     }
 
-    public function passTooManyUsernames(FunctionalTester $I) {
+    /**
+     * @example ["/api/authlib-injector/api/profiles/minecraft"]
+     * @example ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
+     */
+    public function passTooManyUsernames(FunctionalTester $I, Example $url) {
         $I->wantTo('get specific response when pass too many usernames');
         $usernames = [];
         for ($i = 0; $i < 150; $i++) {
             $usernames[] = random_bytes(10);
         }
 
-        $this->route->uuidsByUsernames($usernames);
+        $this->route->uuidsByUsernames($url[0], $usernames);
         $I->canSeeResponseCodeIs(400);
         $I->canSeeResponseIsJson();
         $I->canSeeResponseContainsJson([
@@ -79,9 +104,13 @@ class UsernamesToUuidsCest {
         ]);
     }
 
-    public function passEmptyUsername(FunctionalTester $I) {
+    /**
+     * @example ["/api/authlib-injector/api/profiles/minecraft"]
+     * @example ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
+     */
+    public function passEmptyUsername(FunctionalTester $I, Example $url) {
         $I->wantTo('get specific response when pass empty username');
-        $this->route->uuidsByUsernames(['Admin', '']);
+        $this->route->uuidsByUsernames($url[0], ['Admin', '']);
         $I->canSeeResponseCodeIs(400);
         $I->canSeeResponseIsJson();
         $I->canSeeResponseContainsJson([
@@ -90,9 +119,13 @@ class UsernamesToUuidsCest {
         ]);
     }
 
-    public function passEmptyField(FunctionalTester $I) {
+    /**
+     * @example ["/api/authlib-injector/api/profiles/minecraft"]
+     * @example ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
+     */
+    public function passEmptyField(FunctionalTester $I, Example $url) {
         $I->wantTo('get response when pass empty array');
-        $this->route->uuidsByUsernames([]);
+        $this->route->uuidsByUsernames($url[0], []);
         $I->canSeeResponseCodeIs(400);
         $I->canSeeResponseIsJson();
         $I->canSeeResponseContainsJson([

--- a/api/tests/functional/mojang/UsernamesToUuidsCest.php
+++ b/api/tests/functional/mojang/UsernamesToUuidsCest.php
@@ -1,28 +1,16 @@
 <?php
 namespace api\tests\functional\authserver;
 
-use api\tests\_pages\MojangApiRoute;
 use api\tests\FunctionalTester;
 use Codeception\Example;
 
 class UsernamesToUuidsCest {
-
     /**
-     * @var MojangApiRoute
+     * @dataProvider bulkProfilesEndpoints
      */
-    private $route;
-
-    public function _before(FunctionalTester $I) {
-        $this->route = new MojangApiRoute($I);
-    }
-
-    /**
-     * @example ["/api/authlib-injector/api/profiles/minecraft"]
-     * @example ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
-     */
-    public function getUuidByOneUsername(FunctionalTester $I, Example $url) {
+    public function getUuidByOneUsername(FunctionalTester $I, Example $url) : void {
         $I->wantTo('get uuid by one username');
-        $this->route->uuidsByUsernames($url[0], ['Admin']);
+        $I->sendPost($url[0], ['Admin']);
         $I->canSeeResponseCodeIs(200);
         $I->canSeeResponseIsJson();
         $I->canSeeResponseContainsJson([
@@ -34,32 +22,29 @@ class UsernamesToUuidsCest {
     }
 
     /**
-     * @example ["/api/authlib-injector/api/profiles/minecraft"]
-     * @example ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
+     * @dataProvider bulkProfilesEndpoints
      */
-    public function getUuidsByUsernames(FunctionalTester $I, Example $url) {
+    public function getUuidsByUsernames(FunctionalTester $I, Example $url) : void {
         $I->wantTo('get uuids by few usernames');
-        $this->route->uuidsByUsernames($url[0], ['Admin', 'AccWithOldPassword', 'Notch']);
+        $I->sendPost($url[0], ['Admin', 'AccWithOldPassword', 'Notch']);
         $this->validateFewValidUsernames($I);
     }
 
     /**
-     * @example ["/api/authlib-injector/api/profiles/minecraft"]
-     * @example ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
+     * @dataProvider bulkProfilesEndpoints
      */
-    public function getUuidsByUsernamesWithPostString(FunctionalTester $I, Example $url) {
+    public function getUuidsByUsernamesWithPostString(FunctionalTester $I, Example $url) : void {
         $I->wantTo('get uuids by few usernames');
-        $this->route->uuidsByUsernames($url[0], json_encode(['Admin', 'AccWithOldPassword', 'Notch']));
+        $I->sendPost($url[0], json_encode(['Admin', 'AccWithOldPassword', 'Notch']));
         $this->validateFewValidUsernames($I);
     }
 
     /**
-     * @example ["/api/authlib-injector/api/profiles/minecraft"]
-     * @example ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
+     * @dataProvider bulkProfilesEndpoints
      */
-    public function getUuidsByPartialNonexistentUsernames(FunctionalTester $I, Example $url) {
+    public function getUuidsByPartialNonexistentUsernames(FunctionalTester $I, Example $url) : void {
         $I->wantTo('get uuids by few usernames and some nonexistent');
-        $this->route->uuidsByUsernames($url[0], ['Admin', 'DeletedAccount', 'not-exists-user']);
+        $I->sendPost($url[0], ['Admin', 'DeletedAccount', 'not-exists-user']);
         $I->canSeeResponseCodeIs(200);
         $I->canSeeResponseIsJson();
         $I->canSeeResponseContainsJson([
@@ -73,29 +58,27 @@ class UsernamesToUuidsCest {
     }
 
     /**
-     * @example ["/api/authlib-injector/api/profiles/minecraft"]
-     * @example ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
+     * @dataProvider bulkProfilesEndpoints
      */
-    public function passAllNonexistentUsernames(FunctionalTester $I, Example $url) {
+    public function passAllNonexistentUsernames(FunctionalTester $I, Example $url) : void {
         $I->wantTo('get specific response when pass all nonexistent usernames');
-        $this->route->uuidsByUsernames($url[0], ['not-exists-1', 'not-exists-2']);
+        $I->sendPost($url[0], ['not-exists-1', 'not-exists-2']);
         $I->canSeeResponseCodeIs(200);
         $I->canSeeResponseIsJson();
         $I->canSeeResponseContainsJson([]);
     }
 
     /**
-     * @example ["/api/authlib-injector/api/profiles/minecraft"]
-     * @example ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
+     * @dataProvider bulkProfilesEndpoints
      */
-    public function passTooManyUsernames(FunctionalTester $I, Example $url) {
+    public function passTooManyUsernames(FunctionalTester $I, Example $url) : void {
         $I->wantTo('get specific response when pass too many usernames');
         $usernames = [];
         for ($i = 0; $i < 150; $i++) {
             $usernames[] = random_bytes(10);
         }
 
-        $this->route->uuidsByUsernames($url[0], $usernames);
+        $I->sendPost($url[0], $usernames);
         $I->canSeeResponseCodeIs(400);
         $I->canSeeResponseIsJson();
         $I->canSeeResponseContainsJson([
@@ -105,12 +88,11 @@ class UsernamesToUuidsCest {
     }
 
     /**
-     * @example ["/api/authlib-injector/api/profiles/minecraft"]
-     * @example ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
+     * @dataProvider bulkProfilesEndpoints
      */
-    public function passEmptyUsername(FunctionalTester $I, Example $url) {
+    public function passEmptyUsername(FunctionalTester $I, Example $url) : void {
         $I->wantTo('get specific response when pass empty username');
-        $this->route->uuidsByUsernames($url[0], ['Admin', '']);
+        $I->sendPost($url[0], ['Admin', '']);
         $I->canSeeResponseCodeIs(400);
         $I->canSeeResponseIsJson();
         $I->canSeeResponseContainsJson([
@@ -120,12 +102,11 @@ class UsernamesToUuidsCest {
     }
 
     /**
-     * @example ["/api/authlib-injector/api/profiles/minecraft"]
-     * @example ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
+     * @dataProvider bulkProfilesEndpoints
      */
-    public function passEmptyField(FunctionalTester $I, Example $url) {
+    public function passEmptyField(FunctionalTester $I, Example $url) : void {
         $I->wantTo('get response when pass empty array');
-        $this->route->uuidsByUsernames($url[0], []);
+        $I->sendPost($url[0], []);
         $I->canSeeResponseCodeIs(400);
         $I->canSeeResponseIsJson();
         $I->canSeeResponseContainsJson([
@@ -134,7 +115,7 @@ class UsernamesToUuidsCest {
         ]);
     }
 
-    private function validateFewValidUsernames(FunctionalTester $I) {
+    private function validateFewValidUsernames(FunctionalTester $I) : void {
         $I->canSeeResponseCodeIs(200);
         $I->canSeeResponseIsJson();
         $I->canSeeResponseContainsJson([
@@ -153,4 +134,10 @@ class UsernamesToUuidsCest {
         ]);
     }
 
+    private function bulkProfilesEndpoints() : array {
+        return [
+            ["/api/authlib-injector/api/profiles/minecraft"],
+            ["/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname"]
+        ];
+    }
 }


### PR DESCRIPTION
As of 23w42a, the endpoint moved to: `POST https://sessionserver.mojang.com/session/minecraft/profile/lookup/bulk/byname`

See https://wiki.vg/Mojang_API#Usernames_to_UUIDs