### PR TITLE
Move new "usernames -> UUIDs" endpoint to the correct location

### DIFF
--- a/api/config/routes.php
+++ b/api/config/routes.php
@@ -41,13 +41,13 @@ return [
     '/minecraft/session/hasJoined' => 'session/session/has-joined',
     '/minecraft/session/legacy/hasJoined' => 'session/session/has-joined-legacy',
     '/minecraft/session/profile/<uuid>' => 'session/session/profile',
-    'POST /minecraft/session/profile/lookup/bulk/byname' => 'mojang/api/uuids-by-usernames',
 
     // Mojang API module routes
     '/mojang/profiles/<username>' => 'mojang/api/uuid-by-username',
     '/mojang/profiles/<uuid>/names' => 'mojang/api/usernames-by-uuid',
     'POST /mojang/profiles' => 'mojang/api/uuids-by-usernames',
     'GET /mojang/services/minecraft/profile' => 'mojang/services/profile',
+    'POST /mojang/services/minecraft/profile/lookup/bulk/byname' => 'mojang/api/uuids-by-usernames',
 
     // authlib-injector
     '/authlib-injector/authserver/<action>' => 'authserver/authentication/<action>',

--- a/api/tests/functional/mojang/UsernamesToUuidsCest.php
+++ b/api/tests/functional/mojang/UsernamesToUuidsCest.php
@@ -137,8 +137,8 @@ class UsernamesToUuidsCest {
 
     private function bulkProfilesEndpoints(): array {
         return [
-            ['/api/authlib-injector/api/profiles/minecraft'],
-            ['/api/authlib-injector/sessionserver/session/minecraft/profile/lookup/bulk/byname'],
+            ['/api/mojang/profiles'],
+            ['/api/mojang/services/minecraft/profile/lookup/bulk/byname'],
         ];
     }
 


### PR DESCRIPTION
In #29, I accidentally added the new endpoint to the session host directory (sessionserver), which isn't correct because it belongs on the *services* host directory (api.minecraftservices). This PR fixes this mistake.
In addition, the regular endpoints are now used in the regular UsernamesToUuidsCest, instead of the injector endpoints