### PR TITLE
fix: use custom Redirect URI validation logic in RefreshTokenGrant

### DIFF
--- a/common/components/OAuth2/Grants/AuthCodeGrant.php
+++ b/common/components/OAuth2/Grants/AuthCodeGrant.php
@@ -4,19 +4,15 @@ declare(strict_types=1);
 namespace common\components\OAuth2\Grants;
 
 use common\components\OAuth2\CryptTrait;
-use common\components\OAuth2\Events\RequestedRefreshToken;
-use common\components\OAuth2\Repositories\PublicScopeRepository;
 use DateInterval;
 use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
-use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Grant\AuthCodeGrant as BaseAuthCodeGrant;
-use League\OAuth2\Server\RequestEvent;
-use Psr\Http\Message\ServerRequestInterface;
-use yii\helpers\StringHelper;
 
 final class AuthCodeGrant extends BaseAuthCodeGrant {
     use CryptTrait;
+    use CheckOfflineAccessScopeTrait;
+    use ValidateRedirectUriTrait;
 
     protected function issueAccessToken(
         DateInterval $accessTokenTTL,
@@ -24,30 +20,8 @@ final class AuthCodeGrant extends BaseAuthCodeGrant {
         ?string $userIdentifier,
         array $scopes = [],
     ): AccessTokenEntityInterface {
-        foreach ($scopes as $i => $scope) {
-            if ($scope->getIdentifier() === PublicScopeRepository::OFFLINE_ACCESS) {
-                unset($scopes[$i]);
-                $this->getEmitter()->emit(new RequestedRefreshToken('refresh_token_requested'));
-            }
-        }
-
+        $this->checkOfflineAccessScope($scopes);
         return parent::issueAccessToken($accessTokenTTL, $client, $userIdentifier, $scopes);
-    }
-
-    protected function validateRedirectUri(
-        string $redirectUri,
-        ClientEntityInterface $client,
-        ServerRequestInterface $request,
-    ): void {
-        $allowedRedirectUris = (array)$client->getRedirectUri();
-        foreach ($allowedRedirectUris as $allowedRedirectUri) {
-            if (StringHelper::startsWith($redirectUri, $allowedRedirectUri)) {
-                return;
-            }
-        }
-
-        $this->getEmitter()->emit(new RequestEvent(RequestEvent::CLIENT_AUTHENTICATION_FAILED, $request));
-        throw OAuthServerException::invalidClient($request);
     }
 
 }

--- a/common/components/OAuth2/Grants/CheckOfflineAccessScopeTrait.php
+++ b/common/components/OAuth2/Grants/CheckOfflineAccessScopeTrait.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace common\components\OAuth2\Grants;
+
+use common\components\OAuth2\Events\RequestedRefreshToken;
+use common\components\OAuth2\Repositories\PublicScopeRepository;
+use League\OAuth2\Server\EventEmitting\EventEmitter;
+
+trait CheckOfflineAccessScopeTrait {
+
+    abstract public function getEmitter(): EventEmitter;
+
+    /**
+     * @param \League\OAuth2\Server\Entities\ScopeEntityInterface[] $scopes
+     */
+    protected function checkOfflineAccessScope(array $scopes = []): void {
+        foreach ($scopes as $i => $scope) {
+            if ($scope->getIdentifier() === PublicScopeRepository::OFFLINE_ACCESS) {
+                unset($scopes[$i]);
+                $this->getEmitter()->emit(new RequestedRefreshToken('refresh_token_requested'));
+            }
+        }
+    }
+
+}

--- a/common/components/OAuth2/Grants/RefreshTokenGrant.php
+++ b/common/components/OAuth2/Grants/RefreshTokenGrant.php
@@ -11,18 +11,16 @@ use InvalidArgumentException;
 use Lcobucci\JWT\Validation\Constraint\LooseValidAt;
 use Lcobucci\JWT\Validation\Validator;
 use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
-use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Entities\RefreshTokenEntityInterface;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Grant\RefreshTokenGrant as BaseRefreshTokenGrant;
-use League\OAuth2\Server\RequestEvent;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
 use Yii;
-use yii\helpers\StringHelper;
 
 final class RefreshTokenGrant extends BaseRefreshTokenGrant {
     use CryptTrait;
+    use ValidateRedirectUriTrait;
 
     /**
      * Previously, refresh tokens were stored in Redis.
@@ -113,22 +111,6 @@ final class RefreshTokenGrant extends BaseRefreshTokenGrant {
             'user_id' => $reader->getAccountId(),
             'expire_time' => null,
         ];
-    }
-
-    protected function validateRedirectUri(
-        string $redirectUri,
-        ClientEntityInterface $client,
-        ServerRequestInterface $request,
-    ): void {
-        $allowedRedirectUris = (array)$client->getRedirectUri();
-        foreach ($allowedRedirectUris as $allowedRedirectUri) {
-            if (StringHelper::startsWith($redirectUri, $allowedRedirectUri)) {
-                return;
-            }
-        }
-
-        $this->getEmitter()->emit(new RequestEvent(RequestEvent::CLIENT_AUTHENTICATION_FAILED, $request));
-        throw OAuthServerException::invalidClient($request);
     }
 
 }

--- a/common/components/OAuth2/Grants/RefreshTokenGrant.php
+++ b/common/components/OAuth2/Grants/RefreshTokenGrant.php
@@ -11,12 +11,15 @@ use InvalidArgumentException;
 use Lcobucci\JWT\Validation\Constraint\LooseValidAt;
 use Lcobucci\JWT\Validation\Validator;
 use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
+use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Entities\RefreshTokenEntityInterface;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Grant\RefreshTokenGrant as BaseRefreshTokenGrant;
+use League\OAuth2\Server\RequestEvent;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
 use Yii;
+use yii\helpers\StringHelper;
 
 final class RefreshTokenGrant extends BaseRefreshTokenGrant {
     use CryptTrait;
@@ -110,6 +113,22 @@ final class RefreshTokenGrant extends BaseRefreshTokenGrant {
             'user_id' => $reader->getAccountId(),
             'expire_time' => null,
         ];
+    }
+
+    protected function validateRedirectUri(
+        string $redirectUri,
+        ClientEntityInterface $client,
+        ServerRequestInterface $request,
+    ): void {
+        $allowedRedirectUris = (array)$client->getRedirectUri();
+        foreach ($allowedRedirectUris as $allowedRedirectUri) {
+            if (StringHelper::startsWith($redirectUri, $allowedRedirectUri)) {
+                return;
+            }
+        }
+
+        $this->getEmitter()->emit(new RequestEvent(RequestEvent::CLIENT_AUTHENTICATION_FAILED, $request));
+        throw OAuthServerException::invalidClient($request);
     }
 
 }

--- a/common/components/OAuth2/Grants/ValidateRedirectUriTrait.php
+++ b/common/components/OAuth2/Grants/ValidateRedirectUriTrait.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace common\components\OAuth2\Grants;
+
+use League\OAuth2\Server\Entities\ClientEntityInterface;
+use League\OAuth2\Server\EventEmitting\EventEmitter;
+use League\OAuth2\Server\Exception\OAuthServerException;
+use League\OAuth2\Server\RequestEvent;
+use Psr\Http\Message\ServerRequestInterface;
+use yii\helpers\StringHelper;
+
+trait ValidateRedirectUriTrait {
+
+    abstract public function getEmitter(): EventEmitter;
+
+    protected function validateRedirectUri(
+        string $redirectUri,
+        ClientEntityInterface $client,
+        ServerRequestInterface $request,
+    ): void {
+        $allowedRedirectUris = (array)$client->getRedirectUri();
+        foreach ($allowedRedirectUris as $allowedRedirectUri) {
+            if (StringHelper::startsWith($redirectUri, $allowedRedirectUri)) {
+                return;
+            }
+        }
+
+        $this->getEmitter()->emit(new RequestEvent(RequestEvent::CLIENT_AUTHENTICATION_FAILED, $request));
+
+        throw OAuthServerException::invalidClient($request);
+    }
+
+}


### PR DESCRIPTION
Closes Octol1ttle/ElyPrismLauncher#33

This PR fixes issues (like the one above) that would occur if a client sent a `redirect_uri` when the grant type was set to `refresh_token`. While the client doesn't have to (and probably shouldn't) send `redirect_uri` when refreshing tokens, the OAuth2 library we are using tries to validate it regardless of the grant type.