### PR TITLE
Update Mojang API response code and messages, implement UUID->Username endpoint

### DIFF
--- a/api/config/routes.php
+++ b/api/config/routes.php
@@ -43,28 +43,12 @@ return [
     '/minecraft/session/profile/<uuid>' => 'session/session/profile',
 
     // Mojang API module routes
+    '/mojang/profiles/<username>' => 'mojang/api/uuid-by-username',
     '/mojang/profiles/<uuid>/names' => 'mojang/api/usernames-by-uuid',
-    [
-        'pattern' => '/mojang/profiles/<username>',
-        'route' => 'mojang/api/uuid-by-username',
-        'defaults' => ['modernResponse' => false],
-    ],
-    [
-        'pattern' => 'POST /mojang/profiles',
-        'route' => 'mojang/api/uuids-by-usernames',
-        'defaults' => ['modernResponse' => false],
-    ],
+    'POST /mojang/profiles' => 'mojang/api/uuids-by-usernames',
     'GET /mojang/services/minecraft/profile' => 'mojang/services/profile',
-    [
-        'pattern' => 'POST /mojang/services/minecraft/profile/lookup/bulk/byname',
-        'route' => 'mojang/api/uuids-by-usernames',
-        'defaults' => ['modernResponse' => true],
-    ],
-    [
-        'pattern' => 'GET /mojang/services/minecraft/profile/lookup/name/<username>',
-        'route' => 'mojang/api/uuid-by-username',
-        'defaults' => ['modernResponse' => true],
-    ],
+    'POST /mojang/services/minecraft/profile/lookup/bulk/byname' => 'mojang/api/uuids-by-usernames',
+    'GET /mojang/services/minecraft/profile/lookup/name/<username>' => 'mojang/api/uuid-by-username',
     'GET /mojang/services/minecraft/profile/lookup/<uuid>' => 'mojang/api/username-by-uuid',
 
     // authlib-injector
@@ -72,20 +56,8 @@ return [
     '/authlib-injector/sessionserver/session/minecraft/join' => 'session/session/join',
     '/authlib-injector/sessionserver/session/minecraft/hasJoined' => 'session/session/has-joined',
     '/authlib-injector/sessionserver/session/minecraft/profile/<uuid>' => 'session/session/profile',
-    [
-        'pattern' => '/authlib-injector/api/profiles/minecraft',
-        'route' => 'mojang/api/uuids-by-usernames',
-        'defaults' => ['modernResponse' => false],
-    ],
-    [
-        'pattern' => '/authlib-injector/minecraftservices/minecraft/profile/lookup/bulk/byname',
-        'route' => 'mojang/api/uuids-by-usernames',
-        'defaults' => ['modernResponse' => true],
-    ],
-    [
-        'pattern' => '/authlib-injector/minecraftservices/minecraft/profile/lookup/name/<username>',
-        'route' => 'mojang/api/uuid-by-username',
-        'defaults' => ['modernResponse' => true],
-    ],
+    '/authlib-injector/api/profiles/minecraft' => 'mojang/api/uuids-by-usernames',
+    '/authlib-injector/minecraftservices/minecraft/profile/lookup/bulk/byname' => 'mojang/api/uuids-by-usernames',
+    '/authlib-injector/minecraftservices/minecraft/profile/lookup/name/<username>' => 'mojang/api/uuid-by-username',
     '/authlib-injector/minecraftservices/minecraft/profile/lookup/<uuid>' => 'mojang/api/username-by-uuid',
 ];

--- a/api/config/routes.php
+++ b/api/config/routes.php
@@ -49,6 +49,7 @@ return [
     'GET /mojang/services/minecraft/profile' => 'mojang/services/profile',
     'POST /mojang/services/minecraft/profile/lookup/bulk/byname' => 'mojang/api/uuids-by-usernames',
     'GET /mojang/services/minecraft/profile/lookup/name/<username>' => 'mojang/api/uuid-by-username',
+    'GET /mojang/services/minecraft/profile/lookup/<uuid>' => 'mojang/api/username-by-uuid',
 
     // authlib-injector
     '/authlib-injector/authserver/<action>' => 'authserver/authentication/<action>',
@@ -58,4 +59,5 @@ return [
     '/authlib-injector/api/profiles/minecraft' => 'mojang/api/uuids-by-usernames',
     '/authlib-injector/minecraftservices/minecraft/profile/lookup/bulk/byname' => 'mojang/api/uuids-by-usernames',
     '/authlib-injector/minecraftservices/minecraft/profile/lookup/name/<username>' => 'mojang/api/uuid-by-username',
+    '/authlib-injector/minecraftservices/minecraft/profile/lookup/<uuid>' => 'mojang/api/username-by-uuid',
 ];

--- a/api/config/routes.php
+++ b/api/config/routes.php
@@ -43,12 +43,28 @@ return [
     '/minecraft/session/profile/<uuid>' => 'session/session/profile',
 
     // Mojang API module routes
-    '/mojang/profiles/<username>' => 'mojang/api/uuid-by-username',
     '/mojang/profiles/<uuid>/names' => 'mojang/api/usernames-by-uuid',
-    'POST /mojang/profiles' => 'mojang/api/uuids-by-usernames',
+    [
+        'pattern' => '/mojang/profiles/<username>',
+        'route' => 'mojang/api/uuid-by-username',
+        'defaults' => ['modernResponse' => false],
+    ],
+    [
+        'pattern' => 'POST /mojang/profiles',
+        'route' => 'mojang/api/uuids-by-usernames',
+        'defaults' => ['modernResponse' => false],
+    ],
     'GET /mojang/services/minecraft/profile' => 'mojang/services/profile',
-    'POST /mojang/services/minecraft/profile/lookup/bulk/byname' => 'mojang/api/uuids-by-usernames',
-    'GET /mojang/services/minecraft/profile/lookup/name/<username>' => 'mojang/api/uuid-by-username',
+    [
+        'pattern' => 'POST /mojang/services/minecraft/profile/lookup/bulk/byname',
+        'route' => 'mojang/api/uuids-by-usernames',
+        'defaults' => ['modernResponse' => true],
+    ],
+    [
+        'pattern' => 'GET /mojang/services/minecraft/profile/lookup/name/<username>',
+        'route' => 'mojang/api/uuid-by-username',
+        'defaults' => ['modernResponse' => true],
+    ],
     'GET /mojang/services/minecraft/profile/lookup/<uuid>' => 'mojang/api/username-by-uuid',
 
     // authlib-injector
@@ -56,8 +72,20 @@ return [
     '/authlib-injector/sessionserver/session/minecraft/join' => 'session/session/join',
     '/authlib-injector/sessionserver/session/minecraft/hasJoined' => 'session/session/has-joined',
     '/authlib-injector/sessionserver/session/minecraft/profile/<uuid>' => 'session/session/profile',
-    '/authlib-injector/api/profiles/minecraft' => 'mojang/api/uuids-by-usernames',
-    '/authlib-injector/minecraftservices/minecraft/profile/lookup/bulk/byname' => 'mojang/api/uuids-by-usernames',
-    '/authlib-injector/minecraftservices/minecraft/profile/lookup/name/<username>' => 'mojang/api/uuid-by-username',
+    [
+        'pattern' => '/authlib-injector/api/profiles/minecraft',
+        'route' => 'mojang/api/uuids-by-usernames',
+        'defaults' => ['modernResponse' => false],
+    ],
+    [
+        'pattern' => '/authlib-injector/minecraftservices/minecraft/profile/lookup/bulk/byname',
+        'route' => 'mojang/api/uuids-by-usernames',
+        'defaults' => ['modernResponse' => true],
+    ],
+    [
+        'pattern' => '/authlib-injector/minecraftservices/minecraft/profile/lookup/name/<username>',
+        'route' => 'mojang/api/uuid-by-username',
+        'defaults' => ['modernResponse' => true],
+    ],
     '/authlib-injector/minecraftservices/minecraft/profile/lookup/<uuid>' => 'mojang/api/username-by-uuid',
 ];

--- a/api/modules/mojang/controllers/ApiController.php
+++ b/api/modules/mojang/controllers/ApiController.php
@@ -27,11 +27,6 @@ class ApiController extends Controller {
         ]);
     }
 
-    private function isModernEndpoint(): bool {
-        $url = Yii::$app->getRequest()->url;
-        return str_contains($url, "mojang/services") || str_contains($url, "minecraftservices");
-    }
-
     public function actionUuidByUsername(string $username, int $at = null): ?array {
         if ($at !== null) {
             /** @var UsernameHistory|null $record */
@@ -152,6 +147,11 @@ class ApiController extends Controller {
         }
 
         return $responseData;
+    }
+
+    private function isModernEndpoint(): bool {
+        $url = Yii::$app->getRequest()->url;
+        return str_contains($url, 'mojang/services') || str_contains($url, 'minecraftservices');
     }
 
     private function noContent(): null {

--- a/api/modules/mojang/controllers/ApiController.php
+++ b/api/modules/mojang/controllers/ApiController.php
@@ -27,7 +27,12 @@ class ApiController extends Controller {
         ]);
     }
 
-    public function actionUuidByUsername(string $username, int $at = null, bool $modernResponse = true): ?array {
+    private function isModernEndpoint(): bool {
+        $url = Yii::$app->getRequest()->url;
+        return str_contains($url, "mojang/services") || str_contains($url, "minecraftservices");
+    }
+
+    public function actionUuidByUsername(string $username, int $at = null): ?array {
         if ($at !== null) {
             /** @var UsernameHistory|null $record */
             $record = UsernameHistory::find()
@@ -52,7 +57,7 @@ class ApiController extends Controller {
         }
 
         if ($account === null || $account->status === Account::STATUS_DELETED) {
-            return $modernResponse ? $this->contentNotFound("Couldn't find any profile with name {$username}") : $this->noContent();
+            return $this->isModernEndpoint() ? $this->contentNotFound("Couldn't find any profile with name {$username}") : $this->noContent();
         }
 
         return [
@@ -113,20 +118,20 @@ class ApiController extends Controller {
         ];
     }
 
-    public function actionUuidsByUsernames(bool $modernResponse): array {
+    public function actionUuidsByUsernames(): array {
         $usernames = Yii::$app->request->post();
         if (empty($usernames)) {
-            return $modernResponse ? $this->constraintViolation('size must be between 1 and 100') : $this->illegalArgumentResponse('Passed array of profile names is an invalid JSON string.');
+            return $this->isModernEndpoint() ? $this->constraintViolation('size must be between 1 and 100') : $this->illegalArgumentResponse('Passed array of profile names is an invalid JSON string.');
         }
 
         $usernames = array_unique($usernames);
         if (count($usernames) > 100) {
-            return $modernResponse ? $this->constraintViolation('size must be between 1 and 100') : $this->illegalArgumentResponse('Not more that 100 profile name per call is allowed.');
+            return $this->isModernEndpoint() ? $this->constraintViolation('size must be between 1 and 100') : $this->illegalArgumentResponse('Not more that 100 profile name per call is allowed.');
         }
 
         foreach ($usernames as $username) {
             if (empty($username) || is_array($username)) {
-                return $modernResponse ? $this->constraintViolation('Invalid profile name') : $this->illegalArgumentResponse('profileName can not be null, empty or array key.');
+                return $this->isModernEndpoint() ? $this->constraintViolation('Invalid profile name') : $this->illegalArgumentResponse('profileName can not be null, empty or array key.');
             }
         }
 

--- a/api/modules/mojang/controllers/ApiController.php
+++ b/api/modules/mojang/controllers/ApiController.php
@@ -13,7 +13,7 @@ use yii\helpers\ArrayHelper;
 use yii\helpers\UnsetArrayValue;
 use yii\web\Response;
 
-class ApiController extends Controller {
+final class ApiController extends Controller {
 
     public function behaviors(): array {
         return ArrayHelper::merge(parent::behaviors(), [
@@ -102,7 +102,6 @@ class ApiController extends Controller {
 
         /** @var Account|null $account */
         $account = Account::findOne(['uuid' => $uuid]);
-
         if ($account === null || $account->status === Account::STATUS_DELETED) {
             return $this->contentNotFound();
         }
@@ -151,51 +150,55 @@ class ApiController extends Controller {
 
     private function isModernEndpoint(): bool {
         $url = Yii::$app->getRequest()->url;
-        return str_contains($url, 'mojang/services') || str_contains($url, 'minecraftservices');
+
+        return str_contains($url, 'mojang/services')
+            || str_contains($url, 'minecraftservices');
     }
 
     private function noContent(): null {
-        $response = Yii::$app->getResponse();
-        $response->setStatusCode(204);
-        $response->format = Response::FORMAT_RAW;
+        $this->response->setStatusCode(204);
+        $this->response->format = Response::FORMAT_RAW;
 
         return null;
     }
 
+    /**
+     * @phpstan-return array<mixed>
+     */
     private function contentNotFound(?string $errorMessage = null): array {
-        $response = Yii::$app->getResponse();
-        $response->setStatusCode(404);
-        $response->format = Response::FORMAT_JSON;
+        $this->response->setStatusCode(404);
         if ($errorMessage === null) {
             return [
-                'path' => Yii::$app->getRequest()->url,
+                'path' => $this->request->url,
                 'error' => 'NOT_FOUND',
                 'errorMessage' => 'Not Found',
             ];
         }
 
         return [
-            'path' => Yii::$app->getRequest()->url,
+            'path' => $this->request->url,
             'errorMessage' => $errorMessage,
         ];
     }
 
+    /**
+     * @phpstan-return array<mixed>
+     */
     private function constraintViolation(string $errorMessage): array {
-        $response = Yii::$app->getResponse();
-        $response->setStatusCode(400);
-        $response->format = Response::FORMAT_JSON;
+        $this->response->setStatusCode(400);
 
         return [
-            'path' => Yii::$app->getRequest()->url,
+            'path' => $this->request->url,
             'error' => 'CONSTRAINT_VIOLATION',
             'errorMessage' => $errorMessage,
         ];
     }
 
+    /**
+     * @phpstan-return array<mixed>
+     */
     private function illegalArgumentResponse(string $errorMessage): array {
-        $response = Yii::$app->getResponse();
-        $response->setStatusCode(400);
-        $response->format = Response::FORMAT_JSON;
+        $this->response->setStatusCode(400);
 
         return [
             'error' => 'IllegalArgumentException',

--- a/api/tests/functional/mojang/UsernameToUuidCest.php
+++ b/api/tests/functional/mojang/UsernameToUuidCest.php
@@ -47,12 +47,17 @@ final class UsernameToUuidCest {
     public function getUuidByUsernameAtWrongMoment(FunctionalTester $I, Example $url): void {
         $I->wantTo('get 204 if passed once used, but changed username at moment, when it was changed');
         $I->sendGET("{$url[0]}/klik201", ['at' => 1474404144]);
-        $I->canSeeResponseCodeIs(404);
-        $I->canSeeResponseIsJson();
-        $I->canSeeResponseContainsJson([
-            'path' => "{$url[0]}/klik201?at=1474404144",
-            'errorMessage' => "Couldn't find any profile with name klik201",
-        ]);
+        if (self::isModernEndpoint($url[0])) {
+            $I->canSeeResponseCodeIs(404);
+            $I->canSeeResponseIsJson();
+            $I->canSeeResponseContainsJson([
+                'path' => "{$url[0]}/klik201?at=1474404144",
+                'errorMessage' => "Couldn't find any profile with name klik201",
+            ]);
+        } else {
+            $I->canSeeResponseCodeIs(204);
+            $I->canSeeResponseEquals('');
+        }
     }
 
     /**
@@ -61,12 +66,17 @@ final class UsernameToUuidCest {
     public function getUuidByUsernameWithoutMoment(FunctionalTester $I, Example $url): void {
         $I->wantTo('get 204 if username not busy and not passed valid time mark, when it was busy');
         $I->sendGET("{$url[0]}/klik201");
-        $I->canSeeResponseCodeIs(404);
-        $I->canSeeResponseIsJson();
-        $I->canSeeResponseContainsJson([
-            'path' => "{$url[0]}/klik201",
-            'errorMessage' => "Couldn't find any profile with name klik201",
-        ]);
+        if (self::isModernEndpoint($url[0])) {
+            $I->canSeeResponseCodeIs(404);
+            $I->canSeeResponseIsJson();
+            $I->canSeeResponseContainsJson([
+                'path' => "{$url[0]}/klik201",
+                'errorMessage' => "Couldn't find any profile with name klik201",
+            ]);
+        } else {
+            $I->canSeeResponseCodeIs(204);
+            $I->canSeeResponseEquals('');
+        }
     }
 
     /**
@@ -75,12 +85,17 @@ final class UsernameToUuidCest {
     public function getUuidByWrongUsername(FunctionalTester $I, Example $url): void {
         $I->wantTo('get user uuid by some wrong username');
         $I->sendGET("{$url[0]}/not-exists-user");
-        $I->canSeeResponseCodeIs(404);
-        $I->canSeeResponseIsJson();
-        $I->canSeeResponseContainsJson([
-            'path' => "{$url[0]}/not-exists-user",
-            'errorMessage' => "Couldn't find any profile with name not-exists-user",
-        ]);
+        if (self::isModernEndpoint($url[0])) {
+            $I->canSeeResponseCodeIs(404);
+            $I->canSeeResponseIsJson();
+            $I->canSeeResponseContainsJson([
+                'path' => "{$url[0]}/not-exists-user",
+                'errorMessage' => "Couldn't find any profile with name not-exists-user",
+            ]);
+        } else {
+            $I->canSeeResponseCodeIs(204);
+            $I->canSeeResponseEquals('');
+        }
     }
 
     /**
@@ -89,12 +104,17 @@ final class UsernameToUuidCest {
     public function getUuidForDeletedAccount(FunctionalTester $I, Example $url): void {
         $I->wantTo('get uuid for account that marked for deleting');
         $I->sendGET("{$url[0]}/DeletedAccount");
-        $I->canSeeResponseCodeIs(404);
-        $I->canSeeResponseIsJson();
-        $I->canSeeResponseContainsJson([
-            'path' => "{$url[0]}/DeletedAccount",
-            'errorMessage' => "Couldn't find any profile with name DeletedAccount",
-        ]);
+        if (self::isModernEndpoint($url[0])) {
+            $I->canSeeResponseCodeIs(404);
+            $I->canSeeResponseIsJson();
+            $I->canSeeResponseContainsJson([
+                'path' => "{$url[0]}/DeletedAccount",
+                'errorMessage' => "Couldn't find any profile with name DeletedAccount",
+            ]);
+        } else {
+            $I->canSeeResponseCodeIs(204);
+            $I->canSeeResponseEquals('');
+        }
     }
 
     public function legacyNonPassedUsername(FunctionalTester $I): void {
@@ -112,6 +132,10 @@ final class UsernameToUuidCest {
             'error' => 'CONSTRAINT_VIOLATION',
             'errorMessage' => 'Invalid UUID string: name',
         ]);
+    }
+
+    private static function isModernEndpoint(string $url): bool {
+        return str_contains($url, 'mojang/services');
     }
 
 }

--- a/api/tests/functional/mojang/UsernameToUuidCest.php
+++ b/api/tests/functional/mojang/UsernameToUuidCest.php
@@ -111,7 +111,7 @@ class UsernameToUuidCest {
         $I->canSeeResponseContainsJson([
             'path' => '/api/mojang/services/minecraft/profile/lookup/name',
             'error' => 'CONSTRAINT_VIOLATION',
-            'errorMessage' => "Invalid UUID string: name",
+            'errorMessage' => 'Invalid UUID string: name',
         ]);
     }
 

--- a/api/tests/functional/mojang/UsernameToUuidCest.php
+++ b/api/tests/functional/mojang/UsernameToUuidCest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace api\tests\functional\mojang;
 
 use api\tests\FunctionalTester;
@@ -6,14 +8,16 @@ use Codeception\Example;
 
 final class UsernameToUuidCest {
 
-    public static function endpoints(): array {
-        return [
-            ['/api/mojang/profiles'],
-            ['/api/mojang/services/minecraft/profile/lookup/name'],
-        ];
+    /**
+     * @return iterable<array{string}>
+     */
+    public static function endpoints(): iterable {
+        yield ['/api/mojang/profiles'];
+        yield ['/api/mojang/services/minecraft/profile/lookup/name'];
     }
 
     /**
+     * @param \Codeception\Example<array{string}> $url
      * @dataProvider endpoints
      */
     public function getUuidByUsername(FunctionalTester $I, Example $url): void {
@@ -28,6 +32,7 @@ final class UsernameToUuidCest {
     }
 
     /**
+     * @param \Codeception\Example<array{string}> $url
      * @dataProvider endpoints
      */
     public function getUuidByUsernameAtMoment(FunctionalTester $I, Example $url): void {
@@ -42,6 +47,7 @@ final class UsernameToUuidCest {
     }
 
     /**
+     * @param \Codeception\Example<array{string}> $url
      * @dataProvider endpoints
      */
     public function getUuidByUsernameAtWrongMoment(FunctionalTester $I, Example $url): void {
@@ -61,6 +67,7 @@ final class UsernameToUuidCest {
     }
 
     /**
+     * @param \Codeception\Example<array{string}> $url
      * @dataProvider endpoints
      */
     public function getUuidByUsernameWithoutMoment(FunctionalTester $I, Example $url): void {
@@ -80,6 +87,7 @@ final class UsernameToUuidCest {
     }
 
     /**
+     * @param \Codeception\Example<array{string}> $url
      * @dataProvider endpoints
      */
     public function getUuidByWrongUsername(FunctionalTester $I, Example $url): void {
@@ -99,6 +107,7 @@ final class UsernameToUuidCest {
     }
 
     /**
+     * @param \Codeception\Example<array{string}> $url
      * @dataProvider endpoints
      */
     public function getUuidForDeletedAccount(FunctionalTester $I, Example $url): void {

--- a/api/tests/functional/mojang/UsernameToUuidCest.php
+++ b/api/tests/functional/mojang/UsernameToUuidCest.php
@@ -4,7 +4,7 @@ namespace api\tests\functional\mojang;
 use api\tests\FunctionalTester;
 use Codeception\Example;
 
-class UsernameToUuidCest {
+final class UsernameToUuidCest {
 
     public static function endpoints(): array {
         return [
@@ -103,8 +103,7 @@ class UsernameToUuidCest {
         $I->canSeeResponseCodeIs(404);
     }
 
-    public function nonPassedUsername(FunctionalTester $I): void {
-        $I->wantTo('get UUID error if no username is passed on new endpoint');
+    public function getUuidForIncompletePath(FunctionalTester $I): void {
         $I->sendGET('/api/mojang/services/minecraft/profile/lookup/name');
         $I->canSeeResponseCodeIs(400);
         $I->canSeeResponseIsJson();

--- a/api/tests/functional/mojang/UsernamesToUuidsCest.php
+++ b/api/tests/functional/mojang/UsernamesToUuidsCest.php
@@ -1,5 +1,5 @@
 <?php
-namespace api\tests\functional\authserver;
+namespace api\tests\functional\mojang;
 
 use api\tests\FunctionalTester;
 use Codeception\Example;
@@ -85,8 +85,9 @@ class UsernamesToUuidsCest {
         $I->canSeeResponseCodeIs(400);
         $I->canSeeResponseIsJson();
         $I->canSeeResponseContainsJson([
-            'error' => 'IllegalArgumentException',
-            'errorMessage' => 'Not more that 100 profile name per call is allowed.',
+            'path' => $case[0],
+            'error' => 'CONSTRAINT_VIOLATION',
+            'errorMessage' => 'size must be between 1 and 100',
         ]);
     }
 
@@ -99,8 +100,9 @@ class UsernamesToUuidsCest {
         $I->canSeeResponseCodeIs(400);
         $I->canSeeResponseIsJson();
         $I->canSeeResponseContainsJson([
-            'error' => 'IllegalArgumentException',
-            'errorMessage' => 'profileName can not be null, empty or array key.',
+            'path' => $case[0],
+            'error' => 'CONSTRAINT_VIOLATION',
+            'errorMessage' => 'Invalid profile name',
         ]);
     }
 
@@ -113,8 +115,9 @@ class UsernamesToUuidsCest {
         $I->canSeeResponseCodeIs(400);
         $I->canSeeResponseIsJson();
         $I->canSeeResponseContainsJson([
-            'error' => 'IllegalArgumentException',
-            'errorMessage' => 'Passed array of profile names is an invalid JSON string.',
+            'path' => $case[0],
+            'error' => 'CONSTRAINT_VIOLATION',
+            'errorMessage' => 'size must be between 1 and 100',
         ]);
     }
 

--- a/api/tests/functional/mojang/UsernamesToUuidsCest.php
+++ b/api/tests/functional/mojang/UsernamesToUuidsCest.php
@@ -84,11 +84,18 @@ class UsernamesToUuidsCest {
         $I->sendPost($case[0], $usernames);
         $I->canSeeResponseCodeIs(400);
         $I->canSeeResponseIsJson();
-        $I->canSeeResponseContainsJson([
-            'path' => $case[0],
-            'error' => 'CONSTRAINT_VIOLATION',
-            'errorMessage' => 'size must be between 1 and 100',
-        ]);
+        if (self::isModernEndpoint($case[0])) {
+            $I->canSeeResponseContainsJson([
+                'path' => $case[0],
+                'error' => 'CONSTRAINT_VIOLATION',
+                'errorMessage' => 'size must be between 1 and 100',
+            ]);
+        } else {
+            $I->canSeeResponseContainsJson([
+                'error' => 'IllegalArgumentException',
+                'errorMessage' => 'Not more that 100 profile name per call is allowed.',
+            ]);
+        }
     }
 
     /**
@@ -99,11 +106,18 @@ class UsernamesToUuidsCest {
         $I->sendPost($case[0], ['Admin', '']);
         $I->canSeeResponseCodeIs(400);
         $I->canSeeResponseIsJson();
-        $I->canSeeResponseContainsJson([
-            'path' => $case[0],
-            'error' => 'CONSTRAINT_VIOLATION',
-            'errorMessage' => 'Invalid profile name',
-        ]);
+        if (self::isModernEndpoint($case[0])) {
+            $I->canSeeResponseContainsJson([
+                'path' => $case[0],
+                'error' => 'CONSTRAINT_VIOLATION',
+                'errorMessage' => 'Invalid profile name',
+            ]);
+        } else {
+            $I->canSeeResponseContainsJson([
+                'error' => 'IllegalArgumentException',
+                'errorMessage' => 'profileName can not be null, empty or array key.',
+            ]);
+        }
     }
 
     /**
@@ -114,11 +128,18 @@ class UsernamesToUuidsCest {
         $I->sendPost($case[0], []);
         $I->canSeeResponseCodeIs(400);
         $I->canSeeResponseIsJson();
-        $I->canSeeResponseContainsJson([
-            'path' => $case[0],
-            'error' => 'CONSTRAINT_VIOLATION',
-            'errorMessage' => 'size must be between 1 and 100',
-        ]);
+        if (self::isModernEndpoint($case[0])) {
+            $I->canSeeResponseContainsJson([
+                'path' => $case[0],
+                'error' => 'CONSTRAINT_VIOLATION',
+                'errorMessage' => 'size must be between 1 and 100',
+            ]);
+        } else {
+            $I->canSeeResponseContainsJson([
+                'error' => 'IllegalArgumentException',
+                'errorMessage' => 'Passed array of profile names is an invalid JSON string.',
+            ]);
+        }
     }
 
     public function bulkProfilesEndpoints(): array {
@@ -126,6 +147,10 @@ class UsernamesToUuidsCest {
             ['/api/mojang/profiles'],
             ['/api/mojang/services/minecraft/profile/lookup/bulk/byname'],
         ];
+    }
+
+    private static function isModernEndpoint(string $url): bool {
+        return str_contains($url, 'mojang/services');
     }
 
     private function validateFewValidUsernames(FunctionalTester $I): void {

--- a/api/tests/functional/mojang/UsernamesToUuidsCest.php
+++ b/api/tests/functional/mojang/UsernamesToUuidsCest.php
@@ -1,12 +1,23 @@
 <?php
+declare(strict_types=1);
+
 namespace api\tests\functional\mojang;
 
 use api\tests\FunctionalTester;
 use Codeception\Example;
 
-class UsernamesToUuidsCest {
+final class UsernamesToUuidsCest {
 
     /**
+     * @return iterable<array{string}>
+     */
+    public function bulkProfilesEndpoints(): iterable {
+        yield ['/api/mojang/profiles'];
+        yield ['/api/mojang/services/minecraft/profile/lookup/bulk/byname'];
+    }
+
+    /**
+     * @param \Codeception\Example<array{string}> $case
      * @dataProvider bulkProfilesEndpoints
      */
     public function getUuidByOneUsername(FunctionalTester $I, Example $case): void {
@@ -23,6 +34,7 @@ class UsernamesToUuidsCest {
     }
 
     /**
+     * @param \Codeception\Example<array{string}> $case
      * @dataProvider bulkProfilesEndpoints
      */
     public function getUuidsByUsernames(FunctionalTester $I, Example $case): void {
@@ -32,6 +44,7 @@ class UsernamesToUuidsCest {
     }
 
     /**
+     * @param \Codeception\Example<array{string}> $case
      * @dataProvider bulkProfilesEndpoints
      */
     public function getUuidsByUsernamesWithPostString(FunctionalTester $I, Example $case): void {
@@ -42,6 +55,7 @@ class UsernamesToUuidsCest {
     }
 
     /**
+     * @param \Codeception\Example<array{string}> $case
      * @dataProvider bulkProfilesEndpoints
      */
     public function getUuidsByPartialNonexistentUsernames(FunctionalTester $I, Example $case): void {
@@ -60,6 +74,7 @@ class UsernamesToUuidsCest {
     }
 
     /**
+     * @param \Codeception\Example<array{string}> $case
      * @dataProvider bulkProfilesEndpoints
      */
     public function passAllNonexistentUsernames(FunctionalTester $I, Example $case): void {
@@ -71,6 +86,7 @@ class UsernamesToUuidsCest {
     }
 
     /**
+     * @param \Codeception\Example<array{string}> $case
      * @dataProvider bulkProfilesEndpoints
      */
     public function passTooManyUsernames(FunctionalTester $I, Example $case): void {
@@ -99,6 +115,7 @@ class UsernamesToUuidsCest {
     }
 
     /**
+     * @param \Codeception\Example<array{string}> $case
      * @dataProvider bulkProfilesEndpoints
      */
     public function passEmptyUsername(FunctionalTester $I, Example $case): void {
@@ -121,6 +138,7 @@ class UsernamesToUuidsCest {
     }
 
     /**
+     * @param \Codeception\Example<array{string}> $case
      * @dataProvider bulkProfilesEndpoints
      */
     public function passEmptyField(FunctionalTester $I, Example $case): void {
@@ -140,13 +158,6 @@ class UsernamesToUuidsCest {
                 'errorMessage' => 'Passed array of profile names is an invalid JSON string.',
             ]);
         }
-    }
-
-    public function bulkProfilesEndpoints(): array {
-        return [
-            ['/api/mojang/profiles'],
-            ['/api/mojang/services/minecraft/profile/lookup/bulk/byname'],
-        ];
     }
 
     private static function isModernEndpoint(string $url): bool {

--- a/api/tests/functional/mojang/UuidToUsernameCest.php
+++ b/api/tests/functional/mojang/UuidToUsernameCest.php
@@ -1,12 +1,13 @@
 <?php
+declare(strict_types=1);
+
 namespace api\tests\functional\mojang;
 
 use api\tests\FunctionalTester;
 
-class UuidToUsernameCest {
+final class UuidToUsernameCest {
 
     public function getUsernameByUuid(FunctionalTester $I): void {
-        $I->wantTo('get username by uuid');
         $I->sendGET('/api/mojang/services/minecraft/profile/lookup/df936908b2e1544d96f82977ec213022');
         $I->canSeeResponseCodeIs(200);
         $I->canSeeResponseIsJson();
@@ -17,7 +18,6 @@ class UuidToUsernameCest {
     }
 
     public function getUsernameByInvalidUuid(FunctionalTester $I): void {
-        $I->wantTo('get username by invalid uuid');
         $I->sendGET('/api/mojang/services/minecraft/profile/lookup/123ABC');
         $I->canSeeResponseCodeIs(400);
         $I->canSeeResponseIsJson();
@@ -29,7 +29,6 @@ class UuidToUsernameCest {
     }
 
     public function getUsernameByWrongUuid(FunctionalTester $I): void {
-        $I->wantTo('get username by wrong uuid');
         $I->sendGET('/api/mojang/services/minecraft/profile/lookup/644b25a8-1b0e-46a8-ad2a-97b53ecbb0a2');
         $I->canSeeResponseCodeIs(404);
         $I->canSeeResponseIsJson();
@@ -41,7 +40,6 @@ class UuidToUsernameCest {
     }
 
     public function getUuidForDeletedAccount(FunctionalTester $I): void {
-        $I->wantTo('get username for account that marked for deleting');
         $I->sendGET('/api/mojang/services/minecraft/profile/lookup/6383de63-8f85-4ed5-92b7-5401a1fa68cd');
         $I->canSeeResponseCodeIs(404);
         $I->canSeeResponseIsJson();
@@ -53,7 +51,6 @@ class UuidToUsernameCest {
     }
 
     public function nonPassedUuid(FunctionalTester $I): void {
-        $I->wantTo('get 404 on not passed uuid');
         $I->sendGET('/api/mojang/services/minecraft/profile/lookup/');
         $I->canSeeResponseCodeIs(404);
     }

--- a/api/tests/functional/mojang/UuidToUsernameCest.php
+++ b/api/tests/functional/mojang/UuidToUsernameCest.php
@@ -7,7 +7,7 @@ class UuidToUsernameCest {
 
     public function getUsernameByUuid(FunctionalTester $I): void {
         $I->wantTo('get username by uuid');
-        $I->sendGET("/api/mojang/services/minecraft/profile/lookup/df936908b2e1544d96f82977ec213022");
+        $I->sendGET('/api/mojang/services/minecraft/profile/lookup/df936908b2e1544d96f82977ec213022');
         $I->canSeeResponseCodeIs(200);
         $I->canSeeResponseIsJson();
         $I->canSeeResponseContainsJson([
@@ -18,23 +18,23 @@ class UuidToUsernameCest {
 
     public function getUsernameByInvalidUuid(FunctionalTester $I): void {
         $I->wantTo('get username by invalid uuid');
-        $I->sendGET("/api/mojang/services/minecraft/profile/lookup/123ABC");
+        $I->sendGET('/api/mojang/services/minecraft/profile/lookup/123ABC');
         $I->canSeeResponseCodeIs(400);
         $I->canSeeResponseIsJson();
         $I->canSeeResponseContainsJson([
             'path' => '/api/mojang/services/minecraft/profile/lookup/123ABC',
             'error' => 'CONSTRAINT_VIOLATION',
-            'errorMessage' => "Invalid UUID string: 123ABC",
+            'errorMessage' => 'Invalid UUID string: 123ABC',
         ]);
     }
 
     public function getUsernameByWrongUuid(FunctionalTester $I): void {
         $I->wantTo('get username by wrong uuid');
-        $I->sendGET("/api/mojang/services/minecraft/profile/lookup/644b25a8-1b0e-46a8-ad2a-97b53ecbb0a2");
+        $I->sendGET('/api/mojang/services/minecraft/profile/lookup/644b25a8-1b0e-46a8-ad2a-97b53ecbb0a2');
         $I->canSeeResponseCodeIs(404);
         $I->canSeeResponseIsJson();
         $I->canSeeResponseContainsJson([
-            'path' => "/api/mojang/services/minecraft/profile/lookup/644b25a8-1b0e-46a8-ad2a-97b53ecbb0a2",
+            'path' => '/api/mojang/services/minecraft/profile/lookup/644b25a8-1b0e-46a8-ad2a-97b53ecbb0a2',
             'error' => 'NOT_FOUND',
             'errorMessage' => 'Not Found',
         ]);
@@ -42,11 +42,11 @@ class UuidToUsernameCest {
 
     public function getUuidForDeletedAccount(FunctionalTester $I): void {
         $I->wantTo('get username for account that marked for deleting');
-        $I->sendGET("/api/mojang/services/minecraft/profile/lookup/6383de63-8f85-4ed5-92b7-5401a1fa68cd");
+        $I->sendGET('/api/mojang/services/minecraft/profile/lookup/6383de63-8f85-4ed5-92b7-5401a1fa68cd');
         $I->canSeeResponseCodeIs(404);
         $I->canSeeResponseIsJson();
         $I->canSeeResponseContainsJson([
-            'path' => "/api/mojang/services/minecraft/profile/lookup/6383de63-8f85-4ed5-92b7-5401a1fa68cd",
+            'path' => '/api/mojang/services/minecraft/profile/lookup/6383de63-8f85-4ed5-92b7-5401a1fa68cd',
             'error' => 'NOT_FOUND',
             'errorMessage' => 'Not Found',
         ]);
@@ -54,7 +54,7 @@ class UuidToUsernameCest {
 
     public function nonPassedUuid(FunctionalTester $I): void {
         $I->wantTo('get 404 on not passed uuid');
-        $I->sendGET("/api/mojang/services/minecraft/profile/lookup/");
+        $I->sendGET('/api/mojang/services/minecraft/profile/lookup/');
         $I->canSeeResponseCodeIs(404);
     }
 

--- a/api/tests/functional/mojang/UuidToUsernameCest.php
+++ b/api/tests/functional/mojang/UuidToUsernameCest.php
@@ -1,0 +1,61 @@
+<?php
+namespace api\tests\functional\mojang;
+
+use api\tests\FunctionalTester;
+
+class UuidToUsernameCest {
+
+    public function getUsernameByUuid(FunctionalTester $I): void {
+        $I->wantTo('get username by uuid');
+        $I->sendGET("/api/mojang/services/minecraft/profile/lookup/df936908b2e1544d96f82977ec213022");
+        $I->canSeeResponseCodeIs(200);
+        $I->canSeeResponseIsJson();
+        $I->canSeeResponseContainsJson([
+            'id' => 'df936908b2e1544d96f82977ec213022',
+            'name' => 'Admin',
+        ]);
+    }
+
+    public function getUsernameByInvalidUuid(FunctionalTester $I): void {
+        $I->wantTo('get username by invalid uuid');
+        $I->sendGET("/api/mojang/services/minecraft/profile/lookup/123ABC");
+        $I->canSeeResponseCodeIs(400);
+        $I->canSeeResponseIsJson();
+        $I->canSeeResponseContainsJson([
+            'path' => '/api/mojang/services/minecraft/profile/lookup/123ABC',
+            'error' => 'CONSTRAINT_VIOLATION',
+            'errorMessage' => "Invalid UUID string: 123ABC",
+        ]);
+    }
+
+    public function getUsernameByWrongUuid(FunctionalTester $I): void {
+        $I->wantTo('get username by wrong uuid');
+        $I->sendGET("/api/mojang/services/minecraft/profile/lookup/644b25a8-1b0e-46a8-ad2a-97b53ecbb0a2");
+        $I->canSeeResponseCodeIs(404);
+        $I->canSeeResponseIsJson();
+        $I->canSeeResponseContainsJson([
+            'path' => "/api/mojang/services/minecraft/profile/lookup/644b25a8-1b0e-46a8-ad2a-97b53ecbb0a2",
+            'error' => 'NOT_FOUND',
+            'errorMessage' => 'Not Found',
+        ]);
+    }
+
+    public function getUuidForDeletedAccount(FunctionalTester $I): void {
+        $I->wantTo('get username for account that marked for deleting');
+        $I->sendGET("/api/mojang/services/minecraft/profile/lookup/6383de63-8f85-4ed5-92b7-5401a1fa68cd");
+        $I->canSeeResponseCodeIs(404);
+        $I->canSeeResponseIsJson();
+        $I->canSeeResponseContainsJson([
+            'path' => "/api/mojang/services/minecraft/profile/lookup/6383de63-8f85-4ed5-92b7-5401a1fa68cd",
+            'error' => 'NOT_FOUND',
+            'errorMessage' => 'Not Found',
+        ]);
+    }
+
+    public function nonPassedUuid(FunctionalTester $I): void {
+        $I->wantTo('get 404 on not passed uuid');
+        $I->sendGET("/api/mojang/services/minecraft/profile/lookup/");
+        $I->canSeeResponseCodeIs(404);
+    }
+
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -406,36 +406,6 @@ parameters:
 			path: api/modules/internal/controllers/AccountsController.php
 
 		-
-			message: "#^Call to an undefined method yii\\\\console\\\\Response\\|yii\\\\web\\\\Response\\:\\:setStatusCode\\(\\)\\.$#"
-			count: 2
-			path: api/modules/mojang/controllers/ApiController.php
-
-		-
-			message: "#^Method api\\\\modules\\\\mojang\\\\controllers\\\\ApiController\\:\\:actionUsernamesByUuid\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: api/modules/mojang/controllers/ApiController.php
-
-		-
-			message: "#^Method api\\\\modules\\\\mojang\\\\controllers\\\\ApiController\\:\\:actionUuidByUsername\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: api/modules/mojang/controllers/ApiController.php
-
-		-
-			message: "#^Method api\\\\modules\\\\mojang\\\\controllers\\\\ApiController\\:\\:actionUuidsByUsernames\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: api/modules/mojang/controllers/ApiController.php
-
-		-
-			message: "#^Method api\\\\modules\\\\mojang\\\\controllers\\\\ApiController\\:\\:illegalArgumentResponse\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: api/modules/mojang/controllers/ApiController.php
-
-		-
-			message: "#^Method api\\\\modules\\\\mojang\\\\controllers\\\\ApiController\\:\\:noContentResponse\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: api/modules/mojang/controllers/ApiController.php
-
-		-
 			message: "#^Method api\\\\modules\\\\oauth\\\\controllers\\\\AuthorizationController\\:\\:verbs\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: api/modules/oauth/controllers/AuthorizationController.php
@@ -751,51 +721,6 @@ parameters:
 			path: api/tests/functional/authlibInjector/JoinCest.php
 
 		-
-			message: "#^Method api\\\\tests\\\\functional\\\\authlibInjector\\\\MinecraftProfilesCest\\:\\:bulkProfilesEndpoints\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: api/tests/functional/authlibInjector/MinecraftProfilesCest.php
-
-		-
-			message: "#^Method api\\\\tests\\\\functional\\\\authlibInjector\\\\MinecraftProfilesCest\\:\\:getUuidByOneUsername\\(\\) has parameter \\$case with no value type specified in iterable type Codeception\\\\Example\\.$#"
-			count: 1
-			path: api/tests/functional/authlibInjector/MinecraftProfilesCest.php
-
-		-
-			message: "#^Method api\\\\tests\\\\functional\\\\authlibInjector\\\\MinecraftProfilesCest\\:\\:getUuidsByPartialNonexistentUsernames\\(\\) has parameter \\$case with no value type specified in iterable type Codeception\\\\Example\\.$#"
-			count: 1
-			path: api/tests/functional/authlibInjector/MinecraftProfilesCest.php
-
-		-
-			message: "#^Method api\\\\tests\\\\functional\\\\authlibInjector\\\\MinecraftProfilesCest\\:\\:getUuidsByUsernames\\(\\) has parameter \\$case with no value type specified in iterable type Codeception\\\\Example\\.$#"
-			count: 1
-			path: api/tests/functional/authlibInjector/MinecraftProfilesCest.php
-
-		-
-			message: "#^Method api\\\\tests\\\\functional\\\\authlibInjector\\\\MinecraftProfilesCest\\:\\:getUuidsByUsernamesWithPostString\\(\\) has parameter \\$case with no value type specified in iterable type Codeception\\\\Example\\.$#"
-			count: 1
-			path: api/tests/functional/authlibInjector/MinecraftProfilesCest.php
-
-		-
-			message: "#^Method api\\\\tests\\\\functional\\\\authlibInjector\\\\MinecraftProfilesCest\\:\\:passAllNonexistentUsernames\\(\\) has parameter \\$case with no value type specified in iterable type Codeception\\\\Example\\.$#"
-			count: 1
-			path: api/tests/functional/authlibInjector/MinecraftProfilesCest.php
-
-		-
-			message: "#^Method api\\\\tests\\\\functional\\\\authlibInjector\\\\MinecraftProfilesCest\\:\\:passEmptyField\\(\\) has parameter \\$case with no value type specified in iterable type Codeception\\\\Example\\.$#"
-			count: 1
-			path: api/tests/functional/authlibInjector/MinecraftProfilesCest.php
-
-		-
-			message: "#^Method api\\\\tests\\\\functional\\\\authlibInjector\\\\MinecraftProfilesCest\\:\\:passEmptyUsername\\(\\) has parameter \\$case with no value type specified in iterable type Codeception\\\\Example\\.$#"
-			count: 1
-			path: api/tests/functional/authlibInjector/MinecraftProfilesCest.php
-
-		-
-			message: "#^Method api\\\\tests\\\\functional\\\\authlibInjector\\\\MinecraftProfilesCest\\:\\:passTooManyUsernames\\(\\) has parameter \\$case with no value type specified in iterable type Codeception\\\\Example\\.$#"
-			count: 1
-			path: api/tests/functional/authlibInjector/MinecraftProfilesCest.php
-
-		-
 			message: "#^Method api\\\\tests\\\\functional\\\\authlibInjector\\\\ProfileCest\\:\\:getProfile\\(\\) has parameter \\$case with no value type specified in iterable type Codeception\\\\Example\\.$#"
 			count: 1
 			path: api/tests/functional/authlibInjector/ProfileCest.php
@@ -814,51 +739,6 @@ parameters:
 			message: "#^Method api\\\\tests\\\\functional\\\\authserver\\\\RefreshCest\\:\\:refresh\\(\\) has parameter \\$case with no value type specified in iterable type Codeception\\\\Example\\.$#"
 			count: 1
 			path: api/tests/functional/authserver/RefreshCest.php
-
-		-
-			message: "#^Method api\\\\tests\\\\functional\\\\authserver\\\\UsernamesToUuidsCest\\:\\:bulkProfilesEndpoints\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: api/tests/functional/authserver/UsernamesToUuidsCest.php
-
-		-
-			message: "#^Method api\\\\tests\\\\functional\\\\authserver\\\\UsernamesToUuidsCest\\:\\:getUuidByOneUsername\\(\\) has parameter \\$case with no value type specified in iterable type Codeception\\\\Example\\.$#"
-			count: 1
-			path: api/tests/functional/authserver/UsernamesToUuidsCest.php
-
-		-
-			message: "#^Method api\\\\tests\\\\functional\\\\authserver\\\\UsernamesToUuidsCest\\:\\:getUuidsByPartialNonexistentUsernames\\(\\) has parameter \\$case with no value type specified in iterable type Codeception\\\\Example\\.$#"
-			count: 1
-			path: api/tests/functional/authserver/UsernamesToUuidsCest.php
-
-		-
-			message: "#^Method api\\\\tests\\\\functional\\\\authserver\\\\UsernamesToUuidsCest\\:\\:getUuidsByUsernames\\(\\) has parameter \\$case with no value type specified in iterable type Codeception\\\\Example\\.$#"
-			count: 1
-			path: api/tests/functional/authserver/UsernamesToUuidsCest.php
-
-		-
-			message: "#^Method api\\\\tests\\\\functional\\\\authserver\\\\UsernamesToUuidsCest\\:\\:getUuidsByUsernamesWithPostString\\(\\) has parameter \\$case with no value type specified in iterable type Codeception\\\\Example\\.$#"
-			count: 1
-			path: api/tests/functional/authserver/UsernamesToUuidsCest.php
-
-		-
-			message: "#^Method api\\\\tests\\\\functional\\\\authserver\\\\UsernamesToUuidsCest\\:\\:passAllNonexistentUsernames\\(\\) has parameter \\$case with no value type specified in iterable type Codeception\\\\Example\\.$#"
-			count: 1
-			path: api/tests/functional/authserver/UsernamesToUuidsCest.php
-
-		-
-			message: "#^Method api\\\\tests\\\\functional\\\\authserver\\\\UsernamesToUuidsCest\\:\\:passEmptyField\\(\\) has parameter \\$case with no value type specified in iterable type Codeception\\\\Example\\.$#"
-			count: 1
-			path: api/tests/functional/authserver/UsernamesToUuidsCest.php
-
-		-
-			message: "#^Method api\\\\tests\\\\functional\\\\authserver\\\\UsernamesToUuidsCest\\:\\:passEmptyUsername\\(\\) has parameter \\$case with no value type specified in iterable type Codeception\\\\Example\\.$#"
-			count: 1
-			path: api/tests/functional/authserver/UsernamesToUuidsCest.php
-
-		-
-			message: "#^Method api\\\\tests\\\\functional\\\\authserver\\\\UsernamesToUuidsCest\\:\\:passTooManyUsernames\\(\\) has parameter \\$case with no value type specified in iterable type Codeception\\\\Example\\.$#"
-			count: 1
-			path: api/tests/functional/authserver/UsernamesToUuidsCest.php
 
 		-
 			message: "#^Method api\\\\tests\\\\functional\\\\sessionserver\\\\ProfileCest\\:\\:getProfile\\(\\) has parameter \\$case with no value type specified in iterable type Codeception\\\\Example\\.$#"


### PR DESCRIPTION
This pull request updates Mojang API responses to be in match with api.minecraftservices.com and adds [a new endpoint](https://minecraft.wiki/w/Mojang_API#Query_player's_username)